### PR TITLE
Improve coordinate parsing

### DIFF
--- a/immanuel-mcp-server/tests/test_chart_service.py
+++ b/immanuel-mcp-server/tests/test_chart_service.py
@@ -48,8 +48,8 @@ class TestChartService:
     def test_convert_coordinates_dms_format(self, chart_service: ChartService) -> None:
         """Test coordinate conversion from DMS format."""
         lat, lon = chart_service._convert_coordinates("32n43", "117w09")
-        assert lat == 32.43  # Approximate - depends on implementation
-        assert lon == -117.09
+        assert lat == pytest.approx(32 + 43 / 60.0)
+        assert lon == pytest.approx(-(117 + 9 / 60.0))
     
     def test_convert_coordinates_invalid_format(self, chart_service: ChartService) -> None:
         """Test coordinate conversion with invalid format."""


### PR DESCRIPTION
## Summary
- parse DMS coordinates like `32n43` correctly using regex
- update unit tests for decimal minute conversion

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686581c100f0832394b9b87618f40a73